### PR TITLE
ci: add release step to workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,11 +36,28 @@ jobs:
           name: Fastlane test
           command: bundle exec fastlane mac tests
 
+  release:
+    <<: *default-executor
+
+    steps:
+      - checkout
+      - ruby/install-deps
+      - run:
+          name: Publish new version to cocoapods trunk
+          command: bundle exec fastlane ios release
+
 
 workflows:
-  test-ios:
+  build-test-deploy:
     jobs:
       - build-test-ios
-  test-macos:
-    jobs:
       - build-test-macos
+      - release:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+          requires:
+            - build-test-ios
+            - build-test-macos

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,3 +1,4 @@
+
 platform :ios do
     before_all do
         setup_circle_ci
@@ -13,6 +14,15 @@ platform :ios do
             sdk: "iphonesimulator",
             device: "iPhone 14",
         )
+    end
+
+    desc "Publish to Cocoapods whenever a new version tag is created"
+    lane :release do
+        # publish to Cocoapods
+        # pod_push(
+        #     use_bundle_exec: true,
+        #     path: "AmplifyUtilsNotifications.podspec",
+        # )
     end
 end
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -23,6 +23,14 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 Run all the tests on iOS
 
+### ios release
+
+```sh
+[bundle exec] fastlane ios release
+```
+
+Publish to Cocoapods whenever a new version tag is created
+
 ----
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- add release step to workflow
  - this will need to add an environment variable `COCOAPODS_TRUNK_TOKEN` in CircleCI project setting.
  - I supposed all the version tags are stating with `v`, otherwise we can change the regex

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
