### PR TITLE
chore(ci): push tag to remote before publish cocoapod

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -97,7 +97,8 @@ platform :ios do
         next_version = options[:version]
         UI.user_error!("version shouldn't be nil") if next_version.nil?
 
-        add_git_tag(tag: next_version, grouping: nil)
+        add_git_tag(tag: next_version, grouping: nil, force: true)
+        push_git_tags(tag: next_version, force: true)
     end
 
     desc "Publish new version to cocoapod trunck"
@@ -114,14 +115,12 @@ platform :ios do
         push_to_git_remote(
             local_branch: "release",
             remote_branch: "release",
-            tags: true,
         )
 
         # update main branch with release branch
         push_to_git_remote(
             local_branch: "release",
             remote_branch: "main",
-            tags: true,
         )
     end
 end


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
push the new version tag to remote repo before publishing to cocoapods trunk

BREAKING CHANGE: need to trigger major version bump


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
