### PR TITLE
feat: add support for watchOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,11 @@ import PackageDescription
 
 let package = Package(
     name: "AmplifyUtilsNotifications",
-    platforms: [.iOS(.v13), .macOS(.v10_15)],
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v10_15),
+        .watchOS(.v6)
+    ],
     products: [
         .library(
             name: "AmplifyUtilsNotifications",

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     platforms: [
         .iOS(.v13),
         .macOS(.v10_15),
-        .watchOS(.v6)
+        .watchOS(.v7)
     ],
     products: [
         .library(

--- a/Sources/AmplifyUtilsNotifications/AUNotificationPermissions.swift
+++ b/Sources/AmplifyUtilsNotifications/AUNotificationPermissions.swift
@@ -8,7 +8,9 @@
 import Foundation
 import UserNotifications
 
-#if canImport(AppKit)
+#if canImport(WatchKit)
+import WatchKit
+#elseif canImport(AppKit)
 import AppKit
 typealias Application = NSApplication
 #elseif canImport(UIKit)
@@ -57,7 +59,11 @@ public class AUNotificationPermissions {
     /// Register device with APNs
     public static func registerForRemoteNotifications() async {
         await MainActor.run {
+            #if canImport(WatchKit)
+            WKExtension.shared().registerForRemoteNotifications()
+            #else
             Application.shared.registerForRemoteNotifications()
+            #endif
         }
     }
 }

--- a/Sources/AmplifyUtilsNotifications/AUNotificationPermissions.swift
+++ b/Sources/AmplifyUtilsNotifications/AUNotificationPermissions.swift
@@ -60,7 +60,7 @@ public class AUNotificationPermissions {
     public static func registerForRemoteNotifications() async {
         await MainActor.run {
             #if canImport(WatchKit)
-            WKApplication.shared().registerForRemoteNotifications()
+            WKExtension.shared().registerForRemoteNotifications()
             #else
             Application.shared.registerForRemoteNotifications()
             #endif

--- a/Sources/AmplifyUtilsNotifications/AUNotificationPermissions.swift
+++ b/Sources/AmplifyUtilsNotifications/AUNotificationPermissions.swift
@@ -60,7 +60,7 @@ public class AUNotificationPermissions {
     public static func registerForRemoteNotifications() async {
         await MainActor.run {
             #if canImport(WatchKit)
-            WKExtension.shared().registerForRemoteNotifications()
+            WKApplication.shared().registerForRemoteNotifications()
             #else
             Application.shared.registerForRemoteNotifications()
             #endif


### PR DESCRIPTION
*Description of changes:*
add support for watchOS

- add supported platform version to Package.swift
- registerForRemoteNotifications is part of AppKit/UIKit/WatKit

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
