### PR TITLE
chore: Fixing wrong parsing in release workflow [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           PAT=$(aws secretsmanager get-secret-value \
           --secret-id "$DEPLOY_SECRET_ARN" \
-          | jq ".SecretString | fromjson | .Credential")
+          | jq -r ".SecretString | fromjson | .Credential")
           echo "token=$PAT" >> $GITHUB_OUTPUT
 
       - name: Checkout repo


### PR DESCRIPTION
*Description of changes:*

Unquoting the retrieved token on the release workflow, as it caused the checkout to fail.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
