### PR TITLE
chore: Temporary using xcodeproj's commit that bumps rexml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gem 'cocoapods', '~> 1.11.3'
 gem 'fastlane', '~> 2.211'
 gem 'jazzy', '~> 0.14.3'
+gem "xcodeproj", git: "https://github.com/CocoaPods/Xcodeproj.git", :branch => "master", ref: "fe55cf5"
 eval_gemfile('fastlane/Pluginfile')
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,18 @@
 GIT
+  remote: https://github.com/CocoaPods/Xcodeproj.git
+  revision: fe55cf57badef2ca27fb9d4f801d9b834de1f871
+  ref: fe55cf5
+  branch: master
+  specs:
+    xcodeproj (1.24.0)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.3.0)
+      rexml (>= 3.3.2, < 4.0)
+
+GIT
   remote: https://github.com/aws-amplify/amplify-ci-support
   revision: 74ed2db1f09d93b48129590bcd17cc9b53251756
   branch: main
@@ -9,7 +23,9 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.6)
+    CFPropertyList (3.0.7)
+      base64
+      nkf
       rexml
     activesupport (6.1.7.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -41,6 +57,7 @@ GEM
     aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
+    base64 (0.2.0)
     claide (1.1.0)
     cocoapods (1.11.3)
       addressable (~> 2.8)
@@ -238,6 +255,7 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
+    nkf (0.2.0)
     open4 (1.3.4)
     optparse (0.1.1)
     os (1.1.4)
@@ -250,8 +268,8 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.3.2)
+      strscan
     rouge (2.0.7)
     ruby-macho (2.5.1)
     ruby2_keywords (0.0.5)
@@ -291,13 +309,6 @@ GEM
     word_wrap (1.0.0)
     xcinvoke (0.3.0)
       liferaft (~> 0.0.6)
-    xcodeproj (1.22.0)
-      CFPropertyList (>= 2.3.3, < 4.0)
-      atomos (~> 0.1.3)
-      claide (>= 1.0.2, < 2.0)
-      colored2 (~> 3.1)
-      nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
     xcpretty (0.3.0)
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.1)
@@ -312,6 +323,7 @@ DEPENDENCIES
   fastlane (~> 2.211)
   fastlane-plugin-release_actions!
   jazzy (~> 0.14.3)
+  xcodeproj!
 
 BUNDLED WITH
-   2.1.2
+   2.3.7


### PR DESCRIPTION
**Description of changes:**

This PR uses Xcodeproj's latest [main commit](https://github.com/CocoaPods/Xcodeproj/commit/fe55cf57badef2ca27fb9d4f801d9b834de1f871) so that its dependency to `rexml` can be upgraded.

We're doing this temporary until they release a proper new version, at which point we will point to that one.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
