### PR TITLE
chore: update xcodeproj gem to 1.25.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,5 @@ source 'https://rubygems.org'
 gem 'cocoapods', '~> 1.11.3'
 gem 'fastlane', '~> 2.211'
 gem 'jazzy', '~> 0.14.3'
-gem "xcodeproj", git: "https://github.com/CocoaPods/Xcodeproj.git", :branch => "master", ref: "fe55cf5"
 eval_gemfile('fastlane/Pluginfile')
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,4 @@
 GIT
-  remote: https://github.com/CocoaPods/Xcodeproj.git
-  revision: fe55cf57badef2ca27fb9d4f801d9b834de1f871
-  ref: fe55cf5
-  branch: master
-  specs:
-    xcodeproj (1.24.0)
-      CFPropertyList (>= 2.3.3, < 4.0)
-      atomos (~> 0.1.3)
-      claide (>= 1.0.2, < 2.0)
-      colored2 (~> 3.1)
-      nanaimo (~> 0.3.0)
-      rexml (>= 3.3.2, < 4.0)
-
-GIT
   remote: https://github.com/aws-amplify/amplify-ci-support
   revision: 74ed2db1f09d93b48129590bcd17cc9b53251756
   branch: main
@@ -268,7 +254,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.3.3)
+    rexml (3.3.4)
       strscan
     rouge (2.0.7)
     ruby-macho (2.5.1)
@@ -309,6 +295,13 @@ GEM
     word_wrap (1.0.0)
     xcinvoke (0.3.0)
       liferaft (~> 0.0.6)
+    xcodeproj (1.25.0)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.3.0)
+      rexml (>= 3.3.2, < 4.0)
     xcpretty (0.3.0)
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.1)
@@ -323,7 +316,6 @@ DEPENDENCIES
   fastlane (~> 2.211)
   fastlane-plugin-release_actions!
   jazzy (~> 0.14.3)
-  xcodeproj!
 
 BUNDLED WITH
-   2.3.7
+   2.5.14


### PR DESCRIPTION
*Issue #, if available:*
Dependabot alert for rexml vulnerability

*Description of changes:*
Revert changes in https://github.com/aws-amplify/amplify-swift-utils-notifications/pull/45

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
